### PR TITLE
feat: Show footer copyright line in site footer.

### DIFF
--- a/src/components/SiteFooter/index.js
+++ b/src/components/SiteFooter/index.js
@@ -1,18 +1,27 @@
+import { css } from '@emotion/core';
+import { Paragraph } from '@octopusthink/nautilus';
 import React from 'react';
-import { useStaticQuery, graphql } from 'gatsby';
 
-const { site } = useStaticQuery(graphql`
-  query {
-    site {
-      siteMetadata {
-        copyright
-      }
-    }
-  }
-`);
+import config from 'data/SiteConfig';
 
 const SiteFooter = () => {
-  return <footer>{site.siteMetadata.copyright}</footer>;
+  return (
+    <footer
+      css={css`
+        border-top: 2px solid;
+        margin-top: 4.8rem;
+        margin: 0 auto;
+        max-width: ${config.contentWidth};
+        max-width: ${config.siteContentWidth};
+        padding: 2.4rem 0;
+        text-align: center;
+      `}
+    >
+      <Paragraph small light>
+        {config.copyright}
+      </Paragraph>
+    </footer>
+  );
 };
 
 export default SiteFooter;

--- a/src/components/SiteFooter/index.js
+++ b/src/components/SiteFooter/index.js
@@ -1,7 +1,18 @@
 import React from 'react';
+import { useStaticQuery, graphql } from 'gatsby';
+
+const { site } = useStaticQuery(graphql`
+  query {
+    site {
+      siteMetadata {
+        copyright
+      }
+    }
+  }
+`);
 
 const SiteFooter = () => {
-  return <footer></footer>;
+  return <footer>{site.siteMetadata.copyright}</footer>;
 };
 
 export default SiteFooter;


### PR DESCRIPTION
This adds the footer copyright line from the config file to the site footer:

<img width="745" alt="Screenshot 2020-06-08 at 15 34 47" src="https://user-images.githubusercontent.com/376315/84043047-bcc1d280-a99d-11ea-9a7d-b0c5a984fbe0.png">

Fix #29.

@tofumatt Can you check to make sure I'm not doing anything I shouldn't really quickly? It looks like I've already merged this to master kinda accidentally, but I tried two approaches here to get the data—the first seemed more "correct", but it didn't work. 😞